### PR TITLE
feat: Dynamic routesを利用して、`:name`に応じて表示をだし分ける`/greet`のページを追加

### DIFF
--- a/app/fresh.gen.ts
+++ b/app/fresh.gen.ts
@@ -5,7 +5,8 @@
 import * as $0 from "./routes/[name].tsx";
 import * as $1 from "./routes/about.tsx";
 import * as $2 from "./routes/api/joke.ts";
-import * as $3 from "./routes/index.tsx";
+import * as $3 from "./routes/greet/[name].tsx";
+import * as $4 from "./routes/index.tsx";
 import * as $$0 from "./islands/Counter.tsx";
 
 const manifest = {
@@ -13,7 +14,8 @@ const manifest = {
     "./routes/[name].tsx": $0,
     "./routes/about.tsx": $1,
     "./routes/api/joke.ts": $2,
-    "./routes/index.tsx": $3,
+    "./routes/greet/[name].tsx": $3,
+    "./routes/index.tsx": $4,
   },
   islands: {
     "./islands/Counter.tsx": $$0,

--- a/app/routes/greet/[name].tsx
+++ b/app/routes/greet/[name].tsx
@@ -1,0 +1,14 @@
+// routes/greet/[name].tsx
+
+/** @jsx h */
+import { h } from "preact";
+import { PageProps } from "$fresh/server.ts";
+
+export default function GreetPage(props: PageProps) {
+  const { name } = props.params;
+  return (
+    <main>
+      <p>Greetings to you, {name}!</p>
+    </main>
+  );
+}


### PR DESCRIPTION
## why
Dynamic routesを利用して、`/greet/:name`の`:name`に応じた
表示の出し分けを実現したいため

## do
Dynamic routesを利用して、`:name`に応じて表示をだし分ける`/greet`のページを追加

### sample

http://localhost:8000/greet/nyagato-00
![localhost_8000_greet_nyagato-00(Pixel 5)](https://user-images.githubusercontent.com/12161701/184307070-5d06e9d5-f7dc-4fc1-8f82-2347f9f70a69.png)


## ref
https://fresh.deno.dev/docs/getting-started/dynamic-routes