### PR TITLE
feat: どのページでもナビゲーションを表示できるようにした

### DIFF
--- a/app/components/layouts.tsx
+++ b/app/components/layouts.tsx
@@ -1,0 +1,15 @@
+/** @jsx h */
+import { h } from "preact";
+
+export default function layouts({children}:any) {
+  return (
+    <div>
+      <nav>
+        <a href="/">Home</a>
+        <a href="/about">About</a>
+        <a href="/greet/nyagato-00">nyagato-00</a>
+      </nav>
+      {children}
+    </div>
+  )
+}

--- a/app/routes/about.tsx
+++ b/app/routes/about.tsx
@@ -2,12 +2,13 @@
 
 /** @jsx h */
 import { h } from "preact";
+import Layout from "../components/layouts.tsx";
 
 export default function AboutPage() {
   return (
-    <main>
+    <Layout>
       <h1>About</h1>
       <p>This is the about page.</p>
-    </main>
+    </Layout>
   );
 }

--- a/app/routes/greet/[name].tsx
+++ b/app/routes/greet/[name].tsx
@@ -3,12 +3,15 @@
 /** @jsx h */
 import { h } from "preact";
 import { PageProps } from "$fresh/server.ts";
+import Layout from "../../components/layouts.tsx";
 
 export default function GreetPage(props: PageProps) {
   const { name } = props.params;
   return (
-    <main>
-      <p>Greetings to you, {name}!</p>
-    </main>
+    <Layout>
+      <main>
+        <p>Greetings to you, {name}!</p>
+      </main>
+    </Layout>
   );
 }

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -1,20 +1,11 @@
 /** @jsx h */
 import { h } from "preact";
-import Counter from "../islands/Counter.tsx";
+import Layout from "../components/layouts.tsx";
 
 export default function Home() {
   return (
-    <div class="p-4 mx-auto max-w-screen-md">
-      <img
-        src="/logo.svg"
-        class="w-32 h-32"
-        alt="the fresh logo: a sliced lemon dripping with juice"
-      />
-      <p class="my-6">
-        Welcome to `fresh`. Try updating this message in the ./routes/index.tsx
-        file, and refresh.
-      </p>
-      <Counter start={3} />
-    </div>
+    <Layout>
+        <h1>Welcome to nyagato_00 Fresh App</h1>
+    </Layout>
   );
 }


### PR DESCRIPTION
why
どのページからも、Homeやaboutページにアクセスできるようにしたいため。

do
- layoutファイルを作成
- layoutファイルに共通のナビゲーションバーを実装
- Home・About・Greetから、layoutに実装したナビゲーションバーを表示できるように修正
- Homeにデフォルトで実装されているfreshの＋-ボタン機能を削除

### /home
![スクリーンショット 2022-08-13 9 42 27](https://user-images.githubusercontent.com/12161701/184460917-b3b5ffee-9bae-45a6-8d4e-6aac3ee68279.png)

### /about
![スクリーンショット 2022-08-13 9 42 33](https://user-images.githubusercontent.com/12161701/184460920-82b016bd-57b2-40b0-b94e-1147ffa3ae38.png)

### /greet/nyagato-00
![スクリーンショット 2022-08-13 9 42 38](https://user-images.githubusercontent.com/12161701/184460921-4b876770-ffe3-4427-8070-93162c50edfc.png)
